### PR TITLE
Beatmap lists loads same page multiple times

### DIFF
--- a/src/render/stores/beatmap.store.js
+++ b/src/render/stores/beatmap.store.js
@@ -41,7 +41,8 @@ function createBeatmapStore(endpoint) {
       }));
     },
     loadNextPage: async () => {
-      const { nextPage } = get(store);
+      const { nextPage, loading } = get(store);
+      if (loading) return;
       try {
         store.update(current => ({
           ...current,


### PR DESCRIPTION
Repro:
1. Go to any beatmap list (eg. Hottest)
2. Scroll down until list loader appears
3. Scroll down again while the results are still loading.
4. List will duplicate results (load the same page of results twice)